### PR TITLE
Fixed missing parts of PostgreSQL plugin

### DIFF
--- a/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
+++ b/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,7 +14,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>7066842a</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,28 +35,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.0.5.111-beta\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.5\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.5.111-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.5.15-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence.Sql.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.111-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+    <Reference Include="Akka.Persistence.TestKit, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.5.15-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence.TestKit, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.5.111-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.0.5\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.0.5.111-beta\lib\net45\Akka.TestKit.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.5.111-beta\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
+    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.5\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
@@ -82,18 +78,20 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Wire.0.0.4\lib\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -122,7 +120,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalSpec.cs
@@ -1,6 +1,7 @@
 ﻿using System.Configuration;
 using Akka.Configuration;
 using Akka.Persistence.TestKit.Journal;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.PostgreSql.Tests
 {
@@ -8,7 +9,7 @@ namespace Akka.Persistence.PostgreSql.Tests
     {
         private static readonly Config SpecConfig;
 
-        static PostgreSqlJournalSpec()
+        static PostgreSqlJournalSpec() 
         {
             var connectionString = ConfigurationManager.ConnectionStrings["TestDb"].ConnectionString;
 
@@ -34,8 +35,8 @@ namespace Akka.Persistence.PostgreSql.Tests
             DbUtils.Initialize();
         }
 
-        public PostgreSqlJournalSpec()
-            : base(SpecConfig, "PostgreSqlJournalSpec")
+        public PostgreSqlJournalSpec(ITestOutputHelper output)
+            : base(SpecConfig, "PostgreSqlJournalSpec", output: output)
         {
             Initialize();
         }

--- a/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlSnapshotStoreSpec.cs
@@ -1,6 +1,7 @@
 ﻿using System.Configuration;
 using Akka.Configuration;
 using Akka.Persistence.TestKit.Snapshot;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.PostgreSql.Tests
 {
@@ -34,8 +35,8 @@ namespace Akka.Persistence.PostgreSql.Tests
             DbUtils.Initialize();
         }
 
-        public PostgreSqlSnapshotStoreSpec()
-            : base(SpecConfig, "PostgreSqlSnapshotStoreSpec")
+        public PostgreSqlSnapshotStoreSpec(ITestOutputHelper output)
+            : base(SpecConfig, "PostgreSqlSnapshotStoreSpec", output: output)
         {
             Initialize();
         }

--- a/src/Akka.Persistence.PostgreSql.Tests/app.config
+++ b/src/Akka.Persistence.PostgreSql.Tests/app.config
@@ -3,7 +3,7 @@
   <connectionStrings>
     <add name="TestDb" connectionString="Server=localhost;Port=5432;Database=akka_persistence_tests;User Id=postgres;Password=postgres" providerName="Npgsql" />
   </connectionStrings>
-  <runtime>
+  <!--<runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="xunit.assert" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
@@ -12,6 +12,18 @@
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.2929" newVersion="2.0.0.2929" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>-->
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.assert" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3179" newVersion="2.1.0.3179" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3179" newVersion="2.1.0.3179" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Akka.Persistence.PostgreSql.Tests/packages.config
+++ b/src/Akka.Persistence.PostgreSql.Tests/packages.config
@@ -1,18 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.Sql.Common" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.TestKit" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.TestKit.Xunit2" version="1.0.5.111-beta" targetFramework="net45" />
+  <package id="Akka" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.Persistence" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.TestKit" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.TestKit.Xunit2" version="1.0.5" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Npgsql" version="2.2.5" targetFramework="net45" />
-  <package id="Wire" version="0.0.4" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
+++ b/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
@@ -33,16 +33,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.0.5.111-beta\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.5\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.5.111-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.5.15-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Akka.Persistence.Sql.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.111-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.15-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers">
@@ -67,10 +67,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Wire.0.0.4\lib\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlJournal.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlJournal.cs
@@ -2,6 +2,7 @@
 using System.Data.SqlClient;
 using Akka.Actor;
 using Akka.Persistence.Sql.Common.Journal;
+using Npgsql;
 
 namespace Akka.Persistence.PostgreSql.Journal
 {
@@ -17,7 +18,7 @@ namespace Akka.Persistence.PostgreSql.Journal
 
         protected override DbConnection CreateDbConnection(string connectionString)
         {
-            return new SqlConnection(connectionString);
+            return new NpgsqlConnection(connectionString);
         }
 
         protected override void CopyParamsToCommand(DbCommand sqlCommand, JournalEntry entry)
@@ -37,7 +38,9 @@ namespace Akka.Persistence.PostgreSql.Journal
     /// </summary>
     public class PostgreSqlJournal : SqlJournal
     {
-        public PostgreSqlJournal(JournalDbEngine dbEngine) : base(dbEngine)
+        private readonly PostgreSqlPersistence _extension = PostgreSqlPersistence.Get(Context.System);
+
+        public PostgreSqlJournal() : base(new PostgreSqlJournalEngine(Context.System))
         {
         }
     }

--- a/src/Akka.Persistence.PostgreSql/Journal/QueryBuilder.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/QueryBuilder.cs
@@ -25,7 +25,7 @@ namespace Akka.Persistence.PostgreSql.Journal
             _tableName = tableName;
             _schemaName = schemaName;
 
-            _insertMessagesSql = "INSERT INTO {0}.{1} (persistence_id, sequence_nr, is_deleted, manifest, created_at, payload) VALUES (:persistence_id, :sequence_nr, :is_deleted, :manifest, :created_at, :payload)"
+            _insertMessagesSql = "INSERT INTO {0}.{1} (persistence_id, sequence_nr, is_deleted, manifest, payload, created_at) VALUES (:persistence_id, :sequence_nr, :is_deleted, :manifest, :payload, :created_at)"
                 .QuoteSchemaAndTable(_schemaName, _tableName);
             _selectHighestSequenceNrSql = @"SELECT MAX(sequence_nr) FROM {0}.{1} WHERE persistence_id = :persistence_id".QuoteSchemaAndTable(_schemaName, _tableName);
         }
@@ -39,7 +39,7 @@ namespace Akka.Persistence.PostgreSql.Journal
                 .Where(x => !string.IsNullOrEmpty(x));
 
             var where = string.Join(" AND ", sqlized);
-            var sql = new StringBuilder("SELECT persistence_id, sequence_nr, is_deleted, manifest, created_at, payload FROM {0}.{1} ".QuoteSchemaAndTable(_schemaName, _tableName));
+            var sql = new StringBuilder("SELECT persistence_id, sequence_nr, is_deleted, manifest, payload, created_at FROM {0}.{1} ".QuoteSchemaAndTable(_schemaName, _tableName));
             if (!string.IsNullOrEmpty(where))
             {
                 sql.Append(" WHERE ").Append(where);
@@ -172,8 +172,8 @@ namespace Akka.Persistence.PostgreSql.Journal
                     sequence_nr,
                     is_deleted,
                     manifest,
-                    created_at,
-                    payload ")
+                    payload,
+                    created_at ")
                 .Append(" FROM {0}.{1} WHERE persistence_id = :persistence_id".QuoteSchemaAndTable(_schemaName, _tableName));
 
             // since we guarantee type of fromSequenceNr, toSequenceNr and max

--- a/src/Akka.Persistence.PostgreSql/PostgreSqlInitializer.cs
+++ b/src/Akka.Persistence.PostgreSql/PostgreSqlInitializer.cs
@@ -15,8 +15,8 @@ namespace Akka.Persistence.PostgreSql
                     sequence_nr BIGINT NOT NULL,
                     is_deleted BOOLEAN NOT NULL,
                     manifest VARCHAR(500) NOT NULL,
-                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                     payload BYTEA NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
                     CONSTRAINT {3}_pk PRIMARY KEY (persistence_id, sequence_nr)
                 );
                 CREATE INDEX {3}_sequence_nr_idx ON {0}.{1}(sequence_nr);

--- a/src/Akka.Persistence.PostgreSql/Snapshot/PostgreSqlSnapshotStore.cs
+++ b/src/Akka.Persistence.PostgreSql/Snapshot/PostgreSqlSnapshotStore.cs
@@ -1,13 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Data.SqlClient;
-using System.Threading;
-using System.Threading.Tasks;
-using Akka.Persistence.Snapshot;
-using Npgsql;
-using Akka.Persistence.Sql.Common.Snapshot;
+﻿using System.Data.Common;
 using Akka.Persistence.Sql.Common;
-using System;
-using System.Data.Common;
+using Akka.Persistence.Sql.Common.Snapshot;
+using Npgsql;
 
 namespace Akka.Persistence.PostgreSql.Snapshot
 {
@@ -16,11 +10,10 @@ namespace Akka.Persistence.PostgreSql.Snapshot
     /// </summary>
     public class PostgreSqlSnapshotStore : SqlSnapshotStore
     {
-        private readonly PostgreSqlPersistence _extension;
+        private readonly PostgreSqlPersistence _extension = PostgreSqlPersistence.Get(Context.System);
 
         public PostgreSqlSnapshotStore()
         {
-            _extension = PostgreSqlPersistence.Get(Context.System);
             QueryBuilder = new PostgreSqlSnapshotQueryBuilder(_extension.SnapshotSettings);
             QueryMapper = new PostgreSqlSnapshotQueryMapper(Context.System.Serialization);
         }

--- a/src/Akka.Persistence.PostgreSql/packages.config
+++ b/src/Akka.Persistence.PostgreSql/packages.config
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.Sql.Common" version="1.0.5.111-beta" targetFramework="net45" />
+  <package id="Akka" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.Persistence" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.Sql.Common" version="1.0.5.15-beta" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Npgsql" version="2.2.5" targetFramework="net45" />
-  <package id="Wire" version="0.0.4" targetFramework="net45" />
 </packages>

--- a/src/Akka.Persistence.PostgreSql/postgresql.conf
+++ b/src/Akka.Persistence.PostgreSql/postgresql.conf
@@ -23,6 +23,9 @@
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
+			
+			# timestamp provider used for generation of journal entries timestamps
+			timestamp-provider = "Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common"
 		}
 	}
 


### PR DESCRIPTION
This PR fixes some of the issues found by @r2-r and myself necessary for release of the version 1.0.5, including:

- Missing parameterless constructor for PosgreSQL journal
- Invalind type of connection provider (it was using System.SqlClient instead of Npgsql)
- Invalid order of parameters needed by default journal query mapper
- Missing `timestamp-provider` value in the default HOCON config.
- Upgraded used xUnit version: 2.0 &rArr; 2.1