### PR TITLE
Fixed db initializer connection string resolution

### DIFF
--- a/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
+++ b/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
@@ -61,6 +61,7 @@
       <HintPath>..\packages\Npgsql.2.2.5\lib\net45\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Akka.Persistence.PostgreSql/Extension.cs
+++ b/src/Akka.Persistence.PostgreSql/Extension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Sql.Common;
@@ -81,12 +82,20 @@ namespace Akka.Persistence.PostgreSql
 
             if (JournalSettings.AutoInitialize)
             {
-                PostgreSqlInitializer.CreatePostgreSqlJournalTables(JournalSettings.ConnectionString, JournalSettings.SchemaName, JournalSettings.TableName);
+                var connectionString = string.IsNullOrEmpty(JournalSettings.ConnectionString)
+                    ? ConfigurationManager.ConnectionStrings[JournalSettings.ConnectionStringName].ConnectionString
+                    : JournalSettings.ConnectionString;
+
+                PostgreSqlInitializer.CreatePostgreSqlJournalTables(connectionString, JournalSettings.SchemaName, JournalSettings.TableName);
             }
 
             if (SnapshotSettings.AutoInitialize)
             {
-                PostgreSqlInitializer.CreatePostgreSqlSnapshotStoreTables(SnapshotSettings.ConnectionString, SnapshotSettings.SchemaName, SnapshotSettings.TableName);
+                var connectionString = string.IsNullOrEmpty(SnapshotSettings.ConnectionString)
+                    ? ConfigurationManager.ConnectionStrings[SnapshotSettings.ConnectionStringName].ConnectionString
+                    : SnapshotSettings.ConnectionString;
+
+                PostgreSqlInitializer.CreatePostgreSqlSnapshotStoreTables(connectionString, SnapshotSettings.SchemaName, SnapshotSettings.TableName);
             }
         }
     }


### PR DESCRIPTION
This PR fixes potential problem with SQL table initializer for PostgreSQL. Before it used only HOCON based connection string for connection string resolution. Now it will check for HOCON first, but if connection string was not provided there, it will use second available option - it will try to resolve connection string from app.config based on connection-string-name entry value provided in HOCON.