### PR TITLE
Added persistence query specs and fixed bugs

### DIFF
--- a/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
+++ b/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
@@ -43,6 +43,10 @@
       <HintPath>..\packages\Akka.Persistence.1.0.5.15-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Akka.Persistence.Sql.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.15-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Akka.Persistence.TestKit, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.Persistence.TestKit.1.0.5.15-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
       <Private>True</Private>
@@ -99,6 +103,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DbUtils.cs" />
+    <Compile Include="PostgreSqlJournalQuerySpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PostgreSqlJournalSpec.cs" />
     <Compile Include="PostgreSqlSnapshotStoreSpec.cs" />

--- a/src/Akka.Persistence.PostgreSql.Tests/DbUtils.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/DbUtils.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Configuration;
-using System.Data.SqlClient;
-using Akka.Dispatch.SysMsg;
 using Npgsql;
 
 namespace Akka.Persistence.PostgreSql.Tests

--- a/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalQuerySpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalQuerySpec.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Sql.Common.Journal;
+using Akka.Persistence.Sql.Common.Queries;
+using Akka.Persistence.TestKit;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Akka.Util.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.PostgreSql.Tests
+{
+    public class PostgreSqlJournalQuerySpec : PluginSpec, IDisposable
+    {
+        class TestTimestampProvider : ITimestampProvider
+        {
+            private static IDictionary<Tuple<string, long>, DateTime> KnownEventTimestampMappings = new Dictionary<Tuple<string, long>, DateTime>
+            {
+                {Tuple.Create("p-1", 1L), new DateTime(2001, 1, 1) },
+                {Tuple.Create("p-1", 2L), new DateTime(2001, 1, 2) },
+                {Tuple.Create("p-1", 3L), new DateTime(2001, 1, 3) },
+                {Tuple.Create("p-2", 1L), new DateTime(2001, 1, 1) },
+                {Tuple.Create("p-2", 2L), new DateTime(2001, 2, 1) },
+                {Tuple.Create("p-3", 1L), new DateTime(2001, 1, 1) },
+                {Tuple.Create("p-3", 2L), new DateTime(2003, 1, 1) },
+            };
+
+            public DateTime GenerateTimestamp(IPersistentRepresentation message)
+            {
+                return KnownEventTimestampMappings[Tuple.Create(message.PersistenceId, message.SequenceNr)];
+            }
+        }
+
+        static PostgreSqlJournalQuerySpec()
+        {
+
+            DbUtils.Initialize();
+        }
+
+        private static AtomicCounter counter = new AtomicCounter(0);
+        public static string TimestampConfig(string plugin)
+        {
+            return plugin + ".timestamp-provider =\"" + typeof(TestTimestampProvider).FullName + ", Akka.Persistence.PostgreSql.Tests\"";
+        }
+
+        private static readonly Config SpecConfig = ConfigurationFactory.ParseString(@"
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.postgresql""
+                        postgresql {
+                            class = ""Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            table-name = event_journal
+                            schema-name = public
+                            auto-initialize = on
+                            connection-string-name = ""TestDb""
+                        }
+                    }
+                }
+                " + TimestampConfig("akka.persistence.journal.postgresql"));
+
+        private static readonly IPersistentRepresentation[] Events =
+        {
+            new Persistent("a-1", 1, "System.String", "p-1"),
+            new Persistent("a-2", 2, "System.String", "p-1"),
+            new Persistent("a-3", 3, "System.String", "p-1"),
+            new Persistent("a-4", 1, "System.String", "p-2"),
+            new Persistent(5, 2, "System.Int32", "p-2"),
+            new Persistent(6, 1, "System.Int32", "p-3"),
+            new Persistent("a-7", 2, "System.String", "p-3"),
+        };
+
+        public IActorRef JournalRef { get; protected set; }
+
+        public PostgreSqlJournalQuerySpec(ITestOutputHelper output)
+            : base(SpecConfig, "PostgreSqlJournalQuerySpec", output)
+        {
+            JournalRef = Extension.JournalFor(null);
+            Initialize();
+        }
+
+        [Fact]
+        public void Journal_queried_on_PersistenceIdRange_returns_events_for_particular_persistent_ids()
+        {
+            var query = new Query(1, Hints.PersistenceIds(new[] { "p-1", "p-2" }));
+            QueryAndExpectSuccess(query, Events[0], Events[1], Events[2], Events[3], Events[4]);
+        }
+
+        [Fact]
+        public void Journal_queried_on_Manifest_returns_events_with_particular_manifest()
+        {
+            var query = new Query(2, Hints.Manifest("System.Int32"));
+            QueryAndExpectSuccess(query, Events[4], Events[5]);
+        }
+
+        [Fact]
+        public void Journal_queried_on_Timestamp_returns_events_occurred_after_or_equal_From_value()
+        {
+            var query = new Query(3, Hints.TimestampAfter(new DateTime(2001, 1, 3)));
+            QueryAndExpectSuccess(query, Events[2], Events[4], Events[6]);
+        }
+
+        [Fact]
+        public void Journal_queried_on_Timestamp_returns_events_occurred_before_To_value()
+        {
+            var query = new Query(4, Hints.TimestampBefore(new DateTime(2001, 2, 1)));
+            QueryAndExpectSuccess(query, Events[0], Events[1], Events[2], Events[3], Events[5]);
+        }
+
+        [Fact]
+        public void Journal_queried_on_Timestamp_returns_events_occurred_between_both_range_values()
+        {
+            var query = new Query(5, Hints.TimestampBetween(new DateTime(2001, 1, 3), new DateTime(2003, 1, 1)));
+            QueryAndExpectSuccess(query, Events[2], Events[4]);
+        }
+
+        [Fact]
+        public void Journal_queried_using_multiple_hints_should_apply_all_of_them()
+        {
+            var query = new Query(6,
+                Hints.TimestampBefore(new DateTime(2001, 1, 3)),
+                Hints.PersistenceIds(new[] { "p-1", "p-2" }),
+                Hints.Manifest("System.String"));
+
+            QueryAndExpectSuccess(query, Events[0], Events[1], Events[3]);
+        }
+
+        protected void Initialize()
+        {
+            WriteEvents();
+        }
+
+        private void WriteEvents()
+        {
+            var probe = CreateTestProbe();
+            var message = new WriteMessages(Events, probe.Ref, ActorInstanceId);
+
+            JournalRef.Tell(message);
+            probe.ExpectMsg<WriteMessagesSuccessful>();
+            foreach (var persistent in Events)
+            {
+                probe.ExpectMsg(new WriteMessageSuccess(persistent, ActorInstanceId));
+            }
+        }
+
+        private void QueryAndExpectSuccess(Query query, params IPersistentRepresentation[] events)
+        {
+            JournalRef.Tell(query, TestActor);
+
+            foreach (var e in events)
+            {
+                ExpectMsg<QueryResponse>(q =>
+                    q.QueryId == query.QueryId &&
+                    q.Message.PersistenceId == e.PersistenceId &&
+                    q.Message.SequenceNr == e.SequenceNr &&
+                    q.Message.Manifest == e.Manifest &&
+                    q.Message.IsDeleted == e.IsDeleted &&
+                    Equals(q.Message.Payload, e.Payload));
+            }
+
+            ExpectMsg(new QuerySuccess(query.QueryId));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean();
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql.Tests/packages.config
+++ b/src/Akka.Persistence.PostgreSql.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Akka" version="1.0.5" targetFramework="net45" />
   <package id="Akka.Persistence" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.Sql.Common" version="1.0.5.15-beta" targetFramework="net45" />
   <package id="Akka.Persistence.TestKit" version="1.0.5.15-beta" targetFramework="net45" />
   <package id="Akka.TestKit" version="1.0.5" targetFramework="net45" />
   <package id="Akka.TestKit.Xunit2" version="1.0.5" targetFramework="net45" />

--- a/src/Akka.Persistence.PostgreSql/InternalExtensions.cs
+++ b/src/Akka.Persistence.PostgreSql/InternalExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Data.SqlClient;
-using Npgsql;
+﻿using Npgsql;
 
 namespace Akka.Persistence.PostgreSql
 {

--- a/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlJournal.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlJournal.cs
@@ -1,5 +1,4 @@
 ﻿using System.Data.Common;
-using System.Data.SqlClient;
 using Akka.Actor;
 using Akka.Persistence.Sql.Common.Journal;
 using Npgsql;

--- a/src/Akka.Persistence.PostgreSql/Journal/QueryBuilder.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/QueryBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Data.SqlClient;
 using System.Text;
 using Npgsql;
 using NpgsqlTypes;
@@ -32,7 +30,7 @@ namespace Akka.Persistence.PostgreSql.Journal
 
         public DbCommand SelectEvents(IEnumerable<IHint> hints)
         {
-            var sqlCommand = new SqlCommand();
+            var sqlCommand = new NpgsqlCommand();
 
             var sqlized = hints
                 .Select(h => HintToSql(h, sqlCommand))
@@ -49,7 +47,7 @@ namespace Akka.Persistence.PostgreSql.Journal
             return sqlCommand;
         }
 
-        private string HintToSql(IHint hint, SqlCommand command)
+        private string HintToSql(IHint hint, NpgsqlCommand command)
         {
             if (hint is TimestampRange)
             {
@@ -73,7 +71,7 @@ namespace Akka.Persistence.PostgreSql.Journal
             if (hint is PersistenceIdRange)
             {
                 var range = (PersistenceIdRange)hint;
-                var sb = new StringBuilder(" PersistenceID IN (");
+                var sb = new StringBuilder(" persistence_id IN (");
                 var i = 0;
                 foreach (var persistenceId in range.PersistenceIds)
                 {

--- a/src/Akka.Persistence.PostgreSql/Snapshot/QueryBuilder.cs
+++ b/src/Akka.Persistence.PostgreSql/Snapshot/QueryBuilder.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Data;
-using System.Data.SqlClient;
 using System.Text;
 using Npgsql;
 using NpgsqlTypes;


### PR DESCRIPTION
### Motivation

Right now `Akka.Persistence.PostgreSql` plugin implements SQL persistence queries API. However the test suite for it was not implemented. This PR introduces test suite (based on already existing in core akka repository) for SQL-based journals query API and fixes all breaking bugs found on the way.

### Changes 

- `PostgreSqlJournalQuerySpec` with test suite for postgres journal queries.
- Fixes in naming typos and missused `SqlCommand` instead of `NpgsqlCommand`.