### PR TITLE
upgraded the version of the .NET Core tooling used

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,10 +30,10 @@ Param(
 )
 
 $FakeVersion = "4.61.2"
-$NBenchVersion = "1.0.1"
-$DotNetChannel = "preview";
-$DotNetVersion = "1.0.4";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
+$NBenchVersion = "1.0.4"
+$DotNetChannel = "LTS";
+$DotNetVersion = "2.0.0";
+$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.2.0"

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,8 @@ NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=1.0.4
-DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
+DOTNET_VERSION=2.0.0
+DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/2.0.0/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.
 TARGET="Default"


### PR DESCRIPTION
Can't push to NuGet at the moment - get the following error message:

```
[12:21:50]	[PublishNuget] error: Response status code does not indicate success: 400 (A client version '4.1.0' or higher is required to be able to push packages. Please contact support@nuget.org to get more details.).
```

We already download NuGet v4.1.0 during install, so my guess is that it's the .NET Core tooling that needs to be upgraded here since it takes an internal dependency on NuGet. Bumped from .NET CLI v1.0.4 to 2.0. Let's see if that works.