### PR TITLE
Use array datatype for tags storage and searching

### DIFF
--- a/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
@@ -17,12 +17,11 @@ using System.Collections.Immutable;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Akka.Persistence.PostgreSql.Journal
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-
     public class PostgreSqlQueryExecutor : AbstractQueryExecutor
     {
         private readonly PostgreSqlQueryConfiguration _configuration;


### PR DESCRIPTION
Apparently `tags` is a semicolon-separated list with a `LIKE %%` query against it, which is not that performant when you have millions of events.

PostgreSQL can turn tags into an array type and efficiently index it with a GIN index.

This PR turns the tags column in an array type and changes how tags are inserted and searched for.