### PR TITLE
Move away from legacy BIGSERIAL to BIGINT + IDENTITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ PostgreSql persistence plugin defines a default table schema used for journal, s
 
 ```SQL
 CREATE TABLE {your_journal_table_name} (
-	ordering BIGSERIAL NOT NULL PRIMARY KEY,
+	ordering BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     persistence_id VARCHAR(255) NOT NULL,
     sequence_nr BIGINT NOT NULL,
     is_deleted BOOLEAN NOT NULL,
@@ -111,6 +111,11 @@ CREATE TABLE {your_metadata_table_name} (
 ```
 
 ### Migration
+
+#### From x to x
+```SQL
+TODO: Need some help to write this to go from BIGSERIAL PK to IDENTITY PK
+```
 
 #### From 1.1.0 to 1.3.1
 ```SQL

--- a/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
+++ b/src/Akka.Persistence.PostgreSql/Journal/PostgreSqlQueryExecutor.cs
@@ -35,7 +35,7 @@ namespace Akka.Persistence.PostgreSql.Journal
             
             CreateEventsJournalSql = $@"
                 CREATE TABLE IF NOT EXISTS {Configuration.FullJournalTableName} (
-                    {Configuration.OrderingColumnName} BIGSERIAL NOT NULL PRIMARY KEY,
+                    {Configuration.OrderingColumnName} BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                     {Configuration.PersistenceIdColumnName} VARCHAR(255) NOT NULL,
                     {Configuration.SequenceNrColumnName} BIGINT NOT NULL,
                     {Configuration.IsDeletedColumnName} BOOLEAN NOT NULL,


### PR DESCRIPTION
As of PostgreSQL 10 they introduced IDENTITY to be more in line with the SQL standard, instead of BIGSERIAL, while also avoiding some potential errors with serial.

This PR introduces the code + readme change

@Aaronontheweb would ask for your help in the one TODO in README.md on the migration script.