### PR TITLE
fix logic for json snapshots as highlighted as an issue in #63

### DIFF
--- a/src/Akka.Persistence.PostgreSql/Snapshot/PostgreSqlQueryExecutor.cs
+++ b/src/Akka.Persistence.PostgreSql/Snapshot/PostgreSqlQueryExecutor.cs
@@ -124,7 +124,7 @@ namespace Akka.Persistence.PostgreSql.Snapshot
             {
                 manifest = stringManifest.Manifest(snapshot);
             }
-            else if (!serializer.IncludeManifest)
+            else if (serializer.IncludeManifest)
             {
                 manifest = snapshotType.TypeQualifiedName();
             }
@@ -149,6 +149,7 @@ namespace Akka.Persistence.PostgreSql.Snapshot
             }
             else
             {
+                type = Type.GetType(manifest, false);
                 serializerId = reader.GetInt32(5);
             }
 


### PR DESCRIPTION
Correcting condition for including manifest when writing snapshot data as raised in #63 
This then highlighted the need to pass type when deserializing from json or jsonb

https://github.com/mrhockeymonkey/Akka.Persistence.PostgreSql/blob/a198a4a2ce8526e77b202fa45b10859fe167f3f3/src/Akka.Persistence.PostgreSql/Snapshot/PostgreSqlQueryExecutor.cs#L96

Recovering snapshots when using json now works, resolving #91 