### PR TITLE
Attempt to fix JSON and JSONB payload DbType (failed)

### DIFF
--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonBSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonBSerializationSpec.cs
@@ -5,8 +5,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections.Generic;
+using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Serialization;
+using Akka.Util.Internal;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,6 +55,50 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
         [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
         public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
         {
+        }
+        
+        [Fact]
+        public override void Journal_should_serialize_Persistent_with_string_manifest()
+        {
+            var probe = CreateTestProbe();
+            var persistentEvent = new Persistent(new TestJournal.MyPayload2("b", 5), 1L, Pid, null, false, null, WriterGuid);
+
+            var messages = new List<AtomicWrite>
+            {
+                new AtomicWrite(persistentEvent)
+            };
+
+            Journal.Tell(new WriteMessages(messages, probe.Ref, ActorInstanceId));
+            probe.ExpectMsg<WriteMessagesSuccessful>();
+            probe.ExpectMsg<WriteMessageSuccess>(m => m.ActorInstanceId == ActorInstanceId && m.Persistent.PersistenceId == Pid);
+
+            Journal.Tell(new ReplayMessages(0, long.MaxValue, long.MaxValue, Pid, probe.Ref));
+            probe.ExpectMsg<ReplayedMessage>(s => s.Persistent.PersistenceId == persistentEvent.PersistenceId
+                                                  && s.Persistent.SequenceNr == persistentEvent.SequenceNr
+                                                  && s.Persistent.Payload.AsInstanceOf<TestJournal.MyPayload2>().Data.Equals("b"));
+            probe.ExpectMsg<RecoverySuccess>();
+        }
+
+        [Fact]
+        public override void Journal_should_serialize_Persistent()
+        {
+            var probe = CreateTestProbe();
+            var persistentEvent = new Persistent(new TestJournal.MyPayload("a"), 1L, Pid, null, false, null, WriterGuid);
+
+            var messages = new List<AtomicWrite>
+            {
+                new AtomicWrite(persistentEvent)
+            };
+
+            Journal.Tell(new WriteMessages(messages, probe.Ref, ActorInstanceId));
+            probe.ExpectMsg<WriteMessagesSuccessful>();
+            probe.ExpectMsg<WriteMessageSuccess>(m => m.ActorInstanceId == ActorInstanceId && m.Persistent.PersistenceId == Pid);
+
+            Journal.Tell(new ReplayMessages(0, long.MaxValue, long.MaxValue, Pid, probe.Ref));
+            probe.ExpectMsg<ReplayedMessage>(s => s.Persistent.PersistenceId == Pid
+                                                  && s.Persistent.SequenceNr == persistentEvent.SequenceNr
+                                                  && s.Persistent.Payload.AsInstanceOf<TestJournal.MyPayload>().Data.Equals("a"));
+            probe.ExpectMsg<RecoverySuccess>();
         }
     }
 }

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonBSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonBSerializationSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="PostgreSqlSnapshotStoreSerializationSpec.cs" company="Akka.NET Project">
+// <copyright file="PostgreSqlJournalSerializationSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -13,10 +13,10 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.PostgreSql.Tests.Serialization
 {
     [Collection("PostgreSqlSpec")]
-    public class PostgreSqlSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
+    public class PostgreSqlJournalJsonBSerializationSpec : JournalSerializationSpec
     {
-        public PostgreSqlSnapshotStoreSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
-            : base(CreateSpecConfig(fixture), "PostgreSqlSnapshotStoreSerializationSpec", output)
+        public PostgreSqlJournalJsonBSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
+            : base(CreateSpecConfig(fixture), "PostgreSqlJournalSerializationSpec", output)
         {
         }
 
@@ -31,7 +31,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     journal {{
                         plugin = ""akka.persistence.journal.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = jsonb
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -39,7 +39,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     snapshot-store {{
                         plugin = ""akka.persistence.snapshot-store.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = jsonb
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -47,6 +47,11 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                 }}
                 akka.test.single-expect-default = 10s")
                 .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
+        }
+
+        [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
+        public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
+        {
         }
     }
 }

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalJsonSerializationSpec.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="PostgreSqlSnapshotStoreSerializationSpec.cs" company="Akka.NET Project">
+// <copyright file="PostgreSqlJournalSerializationSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -13,10 +13,10 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.PostgreSql.Tests.Serialization
 {
     [Collection("PostgreSqlSpec")]
-    public class PostgreSqlSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
+    public class PostgreSqlJournalJsonSerializationSpec : JournalSerializationSpec
     {
-        public PostgreSqlSnapshotStoreSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
-            : base(CreateSpecConfig(fixture), "PostgreSqlSnapshotStoreSerializationSpec", output)
+        public PostgreSqlJournalJsonSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
+            : base(CreateSpecConfig(fixture), "PostgreSqlJournalSerializationSpec", output)
         {
         }
 
@@ -31,7 +31,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     journal {{
                         plugin = ""akka.persistence.journal.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = json
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -39,7 +39,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     snapshot-store {{
                         plugin = ""akka.persistence.snapshot-store.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = json
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -47,6 +47,11 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                 }}
                 akka.test.single-expect-default = 10s")
                 .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
+        }
+
+        [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
+        public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
+        {
         }
     }
 }

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlJournalSerializationSpec.cs
@@ -25,22 +25,28 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
             //need to make sure db is created before the tests start
             DbUtils.Initialize(fixture);
 
-            return ConfigurationFactory.ParseString(@"
-                akka.persistence {
+            return ConfigurationFactory.ParseString($@"
+                akka.persistence {{
                     publish-plugin-commands = on
-                    journal {
+                    journal {{
                         plugin = ""akka.persistence.journal.postgresql""
-                        postgresql {
-                            class = ""Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql""
-                            plugin-dispatcher = ""akka.actor.default-dispatcher""
-                            table-name = event_journal
-                            schema-name = public
+                        postgresql {{
+                            stored-as = bytea
+                            connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
-                            connection-string = """ + DbUtils.ConnectionString + @"""
-                        }
-                    }
-                }
-                akka.test.single-expect-default = 10s");
+                        }}
+                    }}
+                    snapshot-store {{
+                        plugin = ""akka.persistence.snapshot-store.postgresql""
+                        postgresql {{
+                            stored-as = bytea
+                            connection-string = ""{DbUtils.ConnectionString}""
+                            auto-initialize = on
+                        }}
+                    }}
+                }}
+                akka.test.single-expect-default = 10s")
+                .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         }
 
         [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonBSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonBSerializationSpec.cs
@@ -8,6 +8,7 @@
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Serialization;
+using Akka.Util.Internal;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Xunit;
@@ -50,6 +51,40 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                 }}
                 akka.test.single-expect-default = 10s")
                 .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
+        }
+
+        [Fact]
+        public override void SnapshotStore_should_serialize_Payload()
+        {
+            var probe = CreateTestProbe();
+
+            var snapshot = new Test.MySnapshot("a");
+
+            var metadata = new SnapshotMetadata(Pid, 1);
+            SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
+            probe.ExpectMsg<SaveSnapshotSuccess>();
+
+            SnapshotStore.Tell(new LoadSnapshot(Pid, SnapshotSelectionCriteria.Latest, long.MaxValue), probe.Ref);
+            probe.ExpectMsg<LoadSnapshotResult>(s => 
+                s.Snapshot.Snapshot is Test.MySnapshot
+                && s.Snapshot.Snapshot.AsInstanceOf<Test.MySnapshot>().Data.Equals("a"));
+        }
+
+        [Fact]
+        public override void SnapshotStore_should_serialize_Payload_with_string_manifest()
+        {
+            var probe = CreateTestProbe();
+
+            var snapshot = new Test.MySnapshot2("a");
+
+            var metadata = new SnapshotMetadata(Pid, 1);
+            SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
+            probe.ExpectMsg<SaveSnapshotSuccess>();
+
+            SnapshotStore.Tell(new LoadSnapshot(Pid, SnapshotSelectionCriteria.Latest, long.MaxValue), probe.Ref);
+            probe.ExpectMsg<LoadSnapshotResult>(s => 
+                s.Snapshot.Snapshot is Test.MySnapshot2
+                && s.Snapshot.Snapshot.AsInstanceOf<Test.MySnapshot2>().Data.Equals("a"));
         }
     }
 }

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonBSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonBSerializationSpec.cs
@@ -5,17 +5,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Serialization;
+using FluentAssertions;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.Persistence.PostgreSql.Tests.Serialization
 {
     [Collection("PostgreSqlSpec")]
-    public class PostgreSqlSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
+    public class PostgreSqlSnapshotStoreJsonBSerializationSpec : SnapshotStoreSerializationSpec
     {
-        public PostgreSqlSnapshotStoreSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
+        public PostgreSqlSnapshotStoreJsonBSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
             : base(CreateSpecConfig(fixture), "PostgreSqlSnapshotStoreSerializationSpec", output)
         {
         }
@@ -31,7 +34,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     journal {{
                         plugin = ""akka.persistence.journal.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = jsonb
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -39,7 +42,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     snapshot-store {{
                         plugin = ""akka.persistence.snapshot-store.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = jsonb
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonSerializationSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/PostgreSqlSnapshotStoreJsonSerializationSpec.cs
@@ -13,9 +13,9 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.PostgreSql.Tests.Serialization
 {
     [Collection("PostgreSqlSpec")]
-    public class PostgreSqlSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
+    public class PostgreSqlSnapshotStoreJsonSerializationSpec : SnapshotStoreSerializationSpec
     {
-        public PostgreSqlSnapshotStoreSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
+        public PostgreSqlSnapshotStoreJsonSerializationSpec(ITestOutputHelper output, PostgresFixture fixture)
             : base(CreateSpecConfig(fixture), "PostgreSqlSnapshotStoreSerializationSpec", output)
         {
         }
@@ -31,7 +31,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     journal {{
                         plugin = ""akka.persistence.journal.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = json
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}
@@ -39,7 +39,7 @@ namespace Akka.Persistence.PostgreSql.Tests.Serialization
                     snapshot-store {{
                         plugin = ""akka.persistence.snapshot-store.postgresql""
                         postgresql {{
-                            stored-as = bytea
+                            stored-as = json
                             connection-string = ""{DbUtils.ConnectionString}""
                             auto-initialize = on
                         }}

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/Test.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/Test.cs
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreTest.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Actor;
+using Akka.Serialization;
+
+namespace Akka.Persistence.PostgreSql.Tests.Serialization
+{
+    internal static class Test
+    {
+        public class MySnapshot
+        {
+            public MySnapshot(string data)
+            {
+                Data = data;
+            }
+
+            public string Data { get; }
+        }
+
+        public class MySnapshot2
+        {
+            public MySnapshot2(string data)
+            {
+                Data = data;
+            }
+
+            public string Data { get; }
+        }
+
+        public class MySnapshotSerializer : Serializer
+        {
+            public MySnapshotSerializer(ExtendedActorSystem system) : base(system) { }
+            public override int Identifier => 77124;
+            public override bool IncludeManifest => true;
+
+            public override byte[] ToBinary(object obj)
+            {
+                if (obj is MySnapshot snapshot) return Encoding.UTF8.GetBytes($".{snapshot.Data}");
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}] in [{nameof(MySnapshotSerializer2)}]");
+            }
+
+            public override object FromBinary(byte[] bytes, Type type)
+            {
+                if (type == typeof(MySnapshot)) return new MySnapshot($"{Encoding.UTF8.GetString(bytes)}.");
+                throw new ArgumentException($"Unimplemented deserialization of message with manifest [{type}] in serializer {nameof(MySnapshotSerializer)}");
+            }
+        }
+
+        public class MySnapshotSerializer2 : SerializerWithStringManifest
+        {
+            private const string ContactsManifest = "A";
+
+            public MySnapshotSerializer2(ExtendedActorSystem system) : base(system) { }
+            public override int Identifier => 77126;
+
+            public override byte[] ToBinary(object obj)
+            {
+                if (obj is MySnapshot2 snapshot) return Encoding.UTF8.GetBytes($".{snapshot.Data}");
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}] in [{nameof(MySnapshotSerializer2)}]");
+            }
+
+            public override string Manifest(object obj)
+            {
+                if (obj is MySnapshot2) return ContactsManifest;
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}] in [{nameof(MySnapshotSerializer2)}]");
+            }
+
+            public override object FromBinary(byte[] bytes, string manifest)
+            {
+                if (manifest == ContactsManifest) return new MySnapshot2(Encoding.UTF8.GetString(bytes) + ".");
+                throw new ArgumentException($"Unimplemented deserialization of message with manifest [{manifest}] in serializer {nameof(MySnapshotSerializer2)}");
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql.Tests/Serialization/TestJournal.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Serialization/TestJournal.cs
@@ -1,0 +1,122 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Model.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Actor;
+using Akka.Persistence.Journal;
+using Akka.Serialization;
+using Akka.Util;
+
+namespace Akka.Persistence.PostgreSql.Tests.Serialization
+{
+    internal static class TestJournal
+    {
+        public class MyPayload
+        {
+            public MyPayload(string data) => Data = data;
+
+            public string Data { get; }
+        }
+
+        public class MyPayload2
+        {
+            public MyPayload2(string data, int n)
+            {
+                Data = data;
+                N = n;
+            }
+
+            public string Data { get; }
+            public int N { get; }
+        }
+
+        public class MyPayload3
+        {
+            public MyPayload3(string data) => Data = data;
+
+            public string Data { get; }
+        }
+
+        public class MyPayloadSerializer : Serializer
+        {
+            public MyPayloadSerializer(ExtendedActorSystem system) : base(system) { }
+
+            public override int Identifier => 77123;
+            public override bool IncludeManifest => true;
+
+            public override byte[] ToBinary(object obj)
+            {
+                if (obj is MyPayload myPayload) return Encoding.UTF8.GetBytes("." + myPayload.Data);
+                if (obj is MyPayload3 myPayload3) return Encoding.UTF8.GetBytes("." + myPayload3.Data);
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}] in [{nameof(MyPayloadSerializer)}]");
+            }
+
+            public override object FromBinary(byte[] bytes, Type type)
+            {
+                if (type == typeof(MyPayload)) return new MyPayload($"{Encoding.UTF8.GetString(bytes)}.");
+                if (type == typeof(MyPayload3)) return new MyPayload3($"{Encoding.UTF8.GetString(bytes)}.");
+                throw new ArgumentException($"Unimplemented deserialization of message with manifest [{type}] in serializer {nameof(MyPayloadSerializer)}");
+            }
+        }
+
+        public class MyPayload2Serializer : SerializerWithStringManifest
+        {
+            private readonly string _manifestV1 = typeof(MyPayload).TypeQualifiedName();
+            private readonly string _manifestV2 = "MyPayload-V2";
+
+            public MyPayload2Serializer(ExtendedActorSystem system) : base(system)
+            {
+            }
+
+            public override int Identifier => 77125;
+
+            public override byte[] ToBinary(object obj)
+            {
+                if (obj is MyPayload2)
+                    return Encoding.UTF8.GetBytes(string.Format(".{0}:{1}", ((MyPayload2)obj).Data, ((MyPayload2)obj).N));
+                return null;
+            }
+
+            public override string Manifest(object o)
+            {
+                return _manifestV2;
+            }
+
+            public override object FromBinary(byte[] bytes, string manifest)
+            {
+                if (manifest.Equals(_manifestV2))
+                {
+                    var parts = Encoding.UTF8.GetString(bytes).Split(':');
+                    return new MyPayload2(parts[0] + ".", int.Parse(parts[1]));
+                }
+                if (manifest.Equals(_manifestV1))
+                    return new MyPayload2(Encoding.UTF8.GetString(bytes) + ".", 0);
+                throw new ArgumentException("unexpected manifest " + manifest);
+            }
+        }
+
+        public class MyWriteAdapter : IWriteEventAdapter
+        {
+            public string Manifest(object evt)
+            {
+                switch (evt)
+                {
+                    case MyPayload3 p when p.Data.Equals("item1"):
+                        return "First-Manifest";
+                    default:
+                        return string.Empty;
+                }
+            }
+            
+            public object ToJournal(object evt)
+            {
+                return evt;
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
+++ b/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
@@ -6,6 +6,7 @@
     <Description>Akka Persistence journal and snapshot store backed by PostgreSql database.</Description>
     <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.PostgreSql/Properties/FriendsOf.cs
+++ b/src/Akka.Persistence.PostgreSql/Properties/FriendsOf.cs
@@ -1,0 +1,10 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Persistence.PostgreSql.Tests")]


### PR DESCRIPTION
Does not Fix #171

The different payload column DbType was never tested. This PR includes serialization tests for JSON and JSONB DbTypes and, as we can see, they failed horrendously.

Problems:
* JSONB rearranges the JSON fields, this can cause polymorphic serializer that depends on a very specific field ordering to fail (ie. Newtonsoft.Json)
* Setting the payload column to JSON/JSONB would mean that we have to ignore the explicit Akka.NET Type to Serializer mapping settings, which is bad. This is the main cause why the TCK is failing.
