### PR TITLE
Dependency fix

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
 
     <!-- Install from version 5.0.11 included all the way up to 8.x.x, but don't go up a major version -->
     <PostgresLowVersion>5.0.11</PostgresLowVersion>
-    <PostgresHighVersion>8</PostgresHighVersion>
-    <PostgresVersion>[$(PostgresLowVersion), $(PostgresHighVersion))</PostgresVersion>
+    <PostgresHighVersion>9</PostgresHighVersion>
+    <PostgresVersion>[$(PostgresLowVersion), $(PostgresHighVersion)]</PostgresVersion>
   </PropertyGroup>
 
   <!-- App dependencies -->


### PR DESCRIPTION
Fixes #
Dependency fix in Directory.Packages.props. Allow all 8.x major versions of Npgsql
