### PR TITLE
Bump Npgsql minimum version to 8.0.3

### DIFF
--- a/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
+++ b/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Docker.DotNet"/>
     <PackageReference Include="Akka.Persistence.Sql.TestKit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="System.Collections.Immutable" /> <!-- Added because of version collision between 7.0 and 8.0 -->
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Npgsql" />

--- a/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
+++ b/src/Akka.Persistence.PostgreSql.Tests/Akka.Persistence.PostgreSql.Tests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Docker.DotNet"/>
     <PackageReference Include="Akka.Persistence.Sql.TestKit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="System.Collections.Immutable" /> <!-- Added because of version collision between 7.0 and 8.0 -->
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Npgsql" />

--- a/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalBigIntSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/PostgreSqlJournalBigIntSpec.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;

--- a/src/Akka.Persistence.PostgreSql.Tests/Query/PostgreSqlCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.PostgreSql.Tests/Query/PostgreSqlCurrentEventsByTagSpec.cs
@@ -10,7 +10,6 @@ using Akka.Persistence.Journal;
 using Akka.Persistence.Query;
 using Akka.Persistence.Query.Sql;
 using Akka.Persistence.TCK.Query;
-using System.Collections.Immutable;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
+++ b/src/Akka.Persistence.PostgreSql/Akka.Persistence.PostgreSql.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" />
     <PackageReference Include="Akka.Persistence.Sql.Common" />
+    <PackageReference Include="System.Collections.Immutable" /> <!-- Added to fix version conflict with Npgsql 8 -->
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,6 +20,7 @@
 
   <!-- Test dependencies -->
   <ItemGroup>
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" /> <!-- Added because of version collision between 7.0 and 8.0 -->
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaVersion)" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,8 +4,8 @@
     <AkkaVersion>1.5.15</AkkaVersion>
     <AkkaHostingVersion>1.5.18</AkkaHostingVersion>
 
-    <!-- Install from version 5.0.11 included all the way up to 8.x.x, but don't go up a major version -->
-    <PostgresLowVersion>5.0.11</PostgresLowVersion>
+    <!-- Install from version 8.0.3 included all the way up to 9.x.x, but don't go up a major version -->
+    <PostgresLowVersion>8.0.3</PostgresLowVersion>
     <PostgresHighVersion>9</PostgresHighVersion>
     <PostgresVersion>[$(PostgresLowVersion), $(PostgresHighVersion)]</PostgresVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Changes

Bump Npgsql minimum version to 8.0.3, in response to [this CVE](https://github.com/advisories/GHSA-x9vc-6hfv-hg8c)